### PR TITLE
Patch sbthost mirror to include range positions.

### DIFF
--- a/sbthost/input/src/main/scala/sbthost/CompiledWithSbthost.scala
+++ b/sbthost/input/src/main/scala/sbthost/CompiledWithSbthost.scala
@@ -4,8 +4,6 @@ import scala.collection.immutable.Seq
 object CompiledWithSbthost {
   def bar(x: Int) = x
   def bar(x: String) = x
-  1 + 2
   bar(1)
   bar("string")
-
 }

--- a/sbthost/runtime/src/main/scala/scala/meta/sbthost/Sbthost.scala
+++ b/sbthost/runtime/src/main/scala/scala/meta/sbthost/Sbthost.scala
@@ -1,0 +1,25 @@
+package scala.meta
+package sbthost
+
+import scala.collection.mutable
+import scala.meta.tokens.Token.Ident
+
+object Sbthost {
+  def patchMirror(mirror: Mirror): Database = {
+    val entries = mirror.database.entries.map {
+      case (input, attrs) =>
+        val endByStart = input.tokenize.get.collect {
+          case t: Ident => t.pos.start -> t.pos.end
+        }.toMap
+        val isTaken = mutable.Set.empty[Point]
+        val names = attrs.names.collect {
+          case (pos @ Position.Range(_, start, end), symbol)
+              if !isTaken(start) && endByStart.contains(start) =>
+            isTaken += start
+            (pos.copy(end = endByStart(start)), symbol)
+        }
+        input -> attrs.copy(names = names)
+    }
+    Database(entries)
+  }
+}


### PR DESCRIPTION
The semanticdb files emitted by sbthost contain only offset positions.
This commit adds a "runtime" library that can use used to patch the
positions of .semanticdb produced by sbthost/2.10 to range positions.

This means that sbt migration rewrites can use the vanilla Semantic API
as long as the mirror is patched first.