### PR TITLE
Use same Symbol/Input data types as scalahost.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+assumeStandardLibraryStripMargin = true
 maxColumn = 100
 align.openParenCallSite = false
 align.openParenDefnSite = false

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/ConfigOps.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/ConfigOps.scala
@@ -1,0 +1,37 @@
+package scala.meta.internal.sbthost
+
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+case class SbthostConfig(sourceroot: Path, targetroot: Path) {
+  def target = targetroot.resolve("META-INF").resolve("semanticdb")
+  def relativePath(path: Path) = sourceroot.relativize(path)
+  def semanticdbPath(relativePath: Path) = {
+    val sibling = relativePath.getFileName.toString + ".semanticdb"
+    target
+      .resolve(relativePath)
+      .resolveSibling(sibling)
+      .toAbsolutePath
+  }
+}
+
+trait ConfigOps { self: DatabaseOps =>
+  def workingDirectory = Paths.get(sys.props("user.dir")).normalize()
+  def targetroot = {
+    val default = Paths
+      .get(
+        g.settings.outputDirs.getSingleOutput
+          .map(_.file.toURI)
+          .getOrElse(new File(g.settings.d.value).getAbsoluteFile.toURI))
+      .normalize()
+    // It seems the default points to the working directory when compiling
+    // sbt builds.
+    if (default == workingDirectory) workingDirectory.resolve("target")
+    else default
+  }
+  var config = SbthostConfig(
+    sourceroot = workingDirectory.toAbsolutePath,
+    targetroot = targetroot.toAbsolutePath
+  )
+}

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/DatabaseOps.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/DatabaseOps.scala
@@ -1,0 +1,12 @@
+package scala.meta.internal.sbthost
+
+import scala.tools.nsc.Global
+
+trait DatabaseOps
+    extends SymbolOps
+    with ConfigOps
+    with InputOps
+    with HijackReporterOps
+    with ReflectionToolkit {
+  val global: Global
+}

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/HijackReporterOps.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/HijackReporterOps.scala
@@ -1,0 +1,29 @@
+package scala.meta.internal.sbthost
+
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.StoreReporter
+
+trait HijackReporterOps { self: DatabaseOps =>
+  def hijackReporter(): Unit = {
+    g.reporter match {
+      case s: StoreReporter =>
+      case s =>
+        val newReporter = new StoreReporter {
+          override def info0(
+              pos: Position,
+              msg: String,
+              severity: Severity,
+              force: Boolean): Unit = {
+            super.info0(pos, msg, severity, force)
+            severity match {
+              case INFO => s.info(pos, msg, force)
+              case WARNING => s.warning(pos, msg)
+              case ERROR => s.error(pos, msg)
+              case _ =>
+            }
+          }
+        }
+        g.reporter = newReporter
+    }
+  }
+}

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/ReflectionToolkit.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/ReflectionToolkit.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.sbthost
+
+import scala.tools.nsc.Global
+
+trait ReflectionToolkit {
+  val global: Global
+  lazy val g: global.type = global
+}

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SbthostPipeline.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SbthostPipeline.scala
@@ -1,0 +1,89 @@
+package scala.meta.internal.sbthost
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.meta.internal.semantic.schema
+import scala.reflect.internal.util.OffsetPosition
+import scala.reflect.internal.util.RangePosition
+import scala.reflect.internal.util.SourceFile
+import scala.tools.nsc.Phase
+import scala.tools.nsc.io.VirtualFile
+import scala.tools.nsc.plugins.PluginComponent
+import scala.tools.nsc.reporters.StoreReporter
+import scala.meta.internal.semantic.{schema => s}
+
+trait SbthostPipeline extends DatabaseOps { self: SbthostPlugin =>
+  object SbthostComponent extends PluginComponent {
+    val global: SbthostPipeline.this.global.type = SbthostPipeline.this.global
+    override val runsAfter = List("typer")
+    override val runsRightAfter = Some("typer")
+    val phaseName = "sbthost"
+    def getMessages(source: SourceFile): mutable.LinkedHashSet[s.Message] =
+      g.reporter match {
+        case reporter: StoreReporter =>
+          reporter.infos.withFilter(_.pos.source == source).map { info =>
+            val range = Option(info.pos).collect {
+              case p: RangePosition => s.Range(p.start, p.end)
+              case p: OffsetPosition => s.Range(p.point, p.point)
+            }
+            val severity = info.severity.id match {
+              case 0 => s.Message.Severity.INFO
+              case 1 => s.Message.Severity.WARNING
+              case 2 => s.Message.Severity.ERROR
+              case els => s.Message.Severity.UNKNOWN
+            }
+            s.Message(range, severity, info.msg)
+          }
+        case els =>
+          //          global.reporter.warning(NoPosition, s"Unknown reporter $els")
+          mutable.LinkedHashSet.empty
+      }
+    def getNames(unit: g.CompilationUnit): Seq[s.ResolvedName] = {
+      val buffer = ListBuffer.newBuilder[s.ResolvedName]
+      object traverser extends g.Traverser {
+
+        def isValidSymbol(symbol: g.Symbol) =
+          symbol.ne(null) && symbol != g.NoSymbol
+
+        override def traverse(tree: g.Tree): Unit = {
+          if (tree.pos.isDefined &&
+              tree.hasSymbol &&
+              isValidSymbol(tree.symbol) &&
+              isValidSymbol(tree.symbol.owner)) {
+            val symbol = tree.symbol.toSemantic
+            val range = s.Range(tree.pos.point, tree.pos.point)
+            buffer += s.ResolvedName(Some(range), symbol.syntax)
+          }
+          super.traverse(tree)
+        }
+      }
+      traverser(unit.body)
+      buffer.result()
+    }
+    override def newPhase(prev: Phase) = new StdPhase(prev) {
+      def apply(unit: g.CompilationUnit): Unit = {
+        val sourcePath = unit.source.file match {
+          case f: VirtualFile =>
+            Paths.get(f.path)
+          case els =>
+            Paths.get(els.file.getAbsoluteFile.toURI)
+        }
+        val filename = config.relativePath(sourcePath)
+        val attributes = s.Attributes(
+          filename = filename.toString,
+          contents = unit.source.content.mkString,
+          dialect = "Scala210", // TODO: not hardcode
+          names = getNames(unit),
+          messages = getMessages(unit.source).toSeq,
+          denotations = Nil,
+          sugars = Nil
+        )
+        val semanticdbOutFile = config.semanticdbPath(filename)
+        semanticdbOutFile.toFile.getParentFile.mkdirs()
+        Files.write(semanticdbOutFile.normalize(), attributes.toByteArray)
+      }
+    }
+  }
+}

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SbthostPlugin.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SbthostPlugin.scala
@@ -1,80 +1,21 @@
 package scala.meta.internal.sbthost
 
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.Paths
-import scala.collection.mutable.ListBuffer
+import scala.meta.internal.sbthost
+import scala.meta.internal.sbthost
 import scala.meta.internal.semantic.{schema => s}
-import scala.reflect.internal.util.OffsetPosition
-import scala.reflect.internal.util.Position
-import scala.reflect.internal.util.RangePosition
-import scala.reflect.internal.util.SourceFile
+import scala.tools.nsc.Global
 import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.plugins.PluginComponent
-import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.nsc.Global
-import scala.tools.nsc.Phase
-import scala.tools.nsc.io.VirtualFile
 
-case class SbthostConfig(sourceroot: Path, targetroot: Path) {
-  def target = targetroot.resolve("META-INF").resolve("semanticdb")
-  def relativePath(path: Path) = sourceroot.relativize(path)
-  def semanticdbPath(relativePath: Path) = {
-    val sibling = relativePath.getFileName.toString + ".semanticdb"
-    target
-      .resolve(relativePath)
-      .resolveSibling(sibling)
-      .toAbsolutePath
-  }
-}
-// NOTE: This is proof-of-concept to show that we can emit .semanticdb files
-// for 2.10. The emitted data is not as accurate as in scalahost, my hypothesis
-// is that it's still better than many other hacks.
-class SbthostPlugin(val global: Global) extends Plugin {
+// NOTE: This plugin is only intended to be used by sbt 0.13 for sbt 1.0 migration.
+// Scalahost is a far superior plugin and should be used instead of sbthost.
+class SbthostPlugin(val global: Global) extends Plugin with SbthostPipeline {
   val name = "sbthost"
   val description = "Compiler plugin for sbt v1.0 migration."
   val components = List[PluginComponent](SbthostComponent)
-  def workingDirectory = Paths.get(sys.props("user.dir")).normalize()
-  def targetroot = {
-    val default = Paths
-      .get(
-        global.settings.outputDirs.getSingleOutput
-          .map(_.file.toURI)
-          .getOrElse(new File(global.settings.d.value).getAbsoluteFile.toURI))
-      .normalize()
-    // It seems the default points to the working directory when compiling
-    // sbt builds.
-    if (default == workingDirectory) workingDirectory.resolve("target")
-    else default
-  }
-  var config = SbthostConfig(
-    sourceroot = workingDirectory.toAbsolutePath,
-    targetroot = targetroot.toAbsolutePath
-  )
-  def hijackReporter() = {
-    global.reporter match {
-      case s: StoreReporter =>
-      case s =>
-        val newReporter = new StoreReporter {
-          override def info0(
-              pos: Position,
-              msg: String,
-              severity: Severity,
-              force: Boolean): Unit = {
-            super.info0(pos, msg, severity, force)
-            severity match {
-              case INFO => s.info(pos, msg, force)
-              case WARNING => s.warning(pos, msg)
-              case ERROR => s.error(pos, msg)
-              case _ =>
-            }
-          }
-        }
-        global.reporter = newReporter
-    }
-  }
-  // Does not work because:
+
+  // Hijacking reporter not work because:
   // [error] (sbthostInput/compile:compileIncremental) java.lang.ClassCastException:
   //   scala.meta.internal.sbthost.SbthostPlugin$$anon$2 cannot be cast to xsbt.DelegatingReporter
   //  hijackReporter()
@@ -85,114 +26,8 @@ class SbthostPlugin(val global: Global) extends Plugin {
       case SetSourceroot(sourceroot) =>
         config = config.copy(sourceroot = Paths.get(sourceroot))
       case els =>
-        global.reporter.error(global.NoPosition, s"Ignoring unknown scalahost option $els")
+        g.reporter.error(g.NoPosition, s"Ignoring unknown scalahost option $els")
     }
   }
 
-  private object SbthostComponent extends PluginComponent {
-    val global = SbthostPlugin.this.global
-    import global._
-    override val runsAfter = List("typer")
-    override val runsRightAfter = Some("typer")
-    val phaseName = "sbthost"
-    def getMessages(source: SourceFile) =
-      global.reporter match {
-        case reporter: StoreReporter =>
-          reporter.infos.withFilter(_.pos.source == source).map { info =>
-            val range = Option(info.pos).collect {
-              case p: RangePosition => s.Range(p.start, p.end)
-              case p: OffsetPosition => s.Range(p.point, p.point)
-            }
-            val severity = info.severity.id match {
-              case 0 => s.Message.Severity.INFO
-              case 1 => s.Message.Severity.WARNING
-              case 2 => s.Message.Severity.ERROR
-              case els => s.Message.Severity.UNKNOWN
-            }
-            s.Message(range, severity, info.msg)
-          }
-        case els =>
-//          global.reporter.warning(NoPosition, s"Unknown reporter $els")
-          Nil
-      }
-    // Copy-pasted from scalahost.
-    def jvmSignature(sym: MethodSymbol): String = {
-      def encode(tpe: Type): String = {
-        val TypeRef(_, sym, args) = tpe
-        require(args.isEmpty || sym == definitions.ArrayClass)
-        if (sym == definitions.UnitClass) "V"
-        else if (sym == definitions.BooleanClass) "Z"
-        else if (sym == definitions.CharClass) "C"
-        else if (sym == definitions.ByteClass) "B"
-        else if (sym == definitions.ShortClass) "S"
-        else if (sym == definitions.IntClass) "I"
-        else if (sym == definitions.FloatClass) "F"
-        else if (sym == definitions.LongClass) "J"
-        else if (sym == definitions.DoubleClass) "D"
-        else if (sym == definitions.ArrayClass) "[" + encode(args.head)
-        else "L" + sym.fullName.replace(".", "/") + ";"
-      }
-      val MethodType(params, ret) = sym.info.erasure
-      val jvmRet =
-        if (!sym.isConstructor) ret else definitions.UnitClass.toType
-      "(" + params
-        .map(param => encode(param.info))
-        .mkString("") + ")" + encode(jvmRet)
-    }
-    def prettySymbol(symbol: Symbol): String = {
-      val buffer = new StringBuilder
-      buffer.append("_root_.")
-      buffer.append(symbol.fullName)
-      if (symbol.isMethod)
-        buffer.append(jvmSignature(symbol.asMethod))
-      buffer.append(".")
-      buffer.toString()
-    }
-    def getNames(unit: global.CompilationUnit): Seq[s.ResolvedName] = {
-      val buffer = ListBuffer.newBuilder[s.ResolvedName]
-      def isValidSymbol(symbol: Symbol) =
-        symbol.ne(null) && symbol != NoSymbol
-      object traverser extends Traverser {
-        override def traverse(tree: Tree): Unit = {
-          if (tree.pos.isDefined && isValidSymbol(tree.symbol)) {
-            val range = s.Range(tree.pos.point, tree.pos.point)
-            val pretty = prettySymbol(tree.symbol)
-            // Hack and hacks, this should not be necessary, just trying to get something running.
-            if (pretty.contains("<") ||
-                pretty.contains(">")) {
-              // nothing
-            } else {
-              buffer += s.ResolvedName(Some(range), pretty)
-            }
-          }
-          super.traverse(tree)
-        }
-      }
-      traverser(unit.body)
-      buffer.result()
-    }
-    override def newPhase(prev: Phase) = new StdPhase(prev) {
-      def apply(unit: global.CompilationUnit): Unit = {
-        val sourcePath = unit.source.file match {
-          case f: VirtualFile =>
-            Paths.get(f.path)
-          case els =>
-            Paths.get(els.file.getAbsoluteFile.toURI)
-        }
-        val filename = config.relativePath(sourcePath)
-        val attributes = s.Attributes(
-          filename = filename.toString,
-          contents = unit.source.content.mkString,
-          dialect = "Scala210", // TODO
-          names = getNames(unit),
-          messages = getMessages(unit.source).toSeq,
-          denotations = Nil,
-          sugars = Nil
-        )
-        val semanticdbOutFile = config.semanticdbPath(filename)
-        semanticdbOutFile.toFile.getParentFile.mkdirs()
-        Files.write(semanticdbOutFile.normalize(), attributes.toByteArray)
-      }
-    }
-  }
 }

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/Symbol.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/Symbol.scala
@@ -1,0 +1,90 @@
+package scala.meta.internal.sbthost
+
+sealed trait Symbol {
+  def syntax: String
+  def structure: String
+}
+
+object Symbol {
+  private def unsupported(sym: Symbol, op: String) = {
+    val receiver = if (sym == None) "Symbol.None" else sym.syntax
+    sys.error(s"Symbol.${op} not supported for $receiver")
+  }
+
+  case object None extends Symbol {
+    override def toString = syntax
+    // + deviation from scalameta
+    override def syntax = "_root_."
+    // override def syntax = ""
+    // - deviation from scalameta
+    override def structure = s"""Symbol.None"""
+  }
+
+  case class Local(id: String) extends Symbol {
+    override def toString = syntax
+    override def syntax = id
+    override def structure = s"""Symbol.Local("$id")"""
+  }
+
+  case class Global(owner: Symbol, signature: Signature) extends Symbol {
+    override def toString = syntax
+    override def syntax = s"${owner.syntax}${signature.syntax}"
+    override def structure = s"""Symbol.Global(${owner.structure}, ${signature.structure})"""
+  }
+
+  case class Multi(symbols: Seq[Symbol]) extends Symbol {
+    override def toString = syntax
+    override def syntax = symbols.map(_.syntax).mkString(";")
+    override def structure = s"""Symbol.Multi(${symbols.map(_.structure).mkString(", ")})"""
+  }
+}
+
+sealed trait Signature {
+  def name: String
+  def syntax: String
+  def structure: String
+}
+
+object Signature {
+  case class Type(name: String) extends Signature {
+    override def syntax = s"${encodeName(name)}#"
+    override def structure = s"""Signature.Type("$name")"""
+    override def toString = syntax
+  }
+
+  case class Term(name: String) extends Signature {
+    override def syntax = s"${encodeName(name)}."
+    override def structure = s"""Signature.Term("$name")"""
+    override def toString = syntax
+  }
+
+  case class Method(name: String, jvmSignature: String) extends Signature {
+    override def syntax = s"${encodeName(name)}$jvmSignature."
+    override def structure = s"""Signature.Method("$name", "$jvmSignature")"""
+    override def toString = syntax
+  }
+
+  case class TypeParameter(name: String) extends Signature {
+    override def syntax = s"[${encodeName(name)}]"
+    override def structure = s"""Signature.TypeParameter("$name")"""
+    override def toString = syntax
+  }
+
+  case class TermParameter(name: String) extends Signature {
+    override def syntax = s"(${encodeName(name)})"
+    override def structure = s"""Signature.TermParameter("$name")"""
+    override def toString = syntax
+  }
+
+  case class Self(name: String) extends Signature {
+    override def syntax = s"${encodeName(name)}=>"
+    override def structure = s"""Signature.Self("$name")"""
+    override def toString = syntax
+  }
+
+  private def encodeName(name: String): String = {
+    val headOk = Character.isJavaIdentifierStart(name.head)
+    val tailOk = name.tail.forall(Character.isJavaIdentifierPart)
+    if (headOk && tailOk) name else "`" + name + "`"
+  }
+}

--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SymbolOps.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SymbolOps.scala
@@ -1,0 +1,93 @@
+package scala.meta.internal.sbthost
+
+import java.nio.file.Path
+import scala.meta.internal.{sbthost => m}
+
+sealed trait Input
+object Input {
+  case object None extends Input
+  case class File(path: Path) extends Input
+}
+
+trait InputOps { self: DatabaseOps =>
+  implicit class XtensionGPosition(pos: g.Position) {
+    def toInput: m.Input = {
+      if ((pos.source.file ne null) &&
+          (pos.source.file.file ne null)) {
+        val relativePath = config.sourceroot.relativize(pos.source.file.file.toPath)
+        m.Input.File(relativePath)
+      } else {
+        m.Input.None
+      }
+    }
+  }
+}
+
+trait SymbolOps { self: DatabaseOps =>
+
+  implicit class XtensionGSymbolMSymbol(sym: g.Symbol) {
+    def toSemantic: m.Symbol = {
+      if (sym == null || sym == g.NoSymbol) return m.Symbol.None
+      if (sym.isOverloaded) return m.Symbol.Multi(sym.alternatives.map(_.toSemantic))
+      if (sym.isModuleClass) return sym.asClass.module.toSemantic
+      if (sym.isRootPackage) return m.Symbol.Global(m.Symbol.None, m.Signature.Term("_root_"))
+      if (sym.isEmptyPackage) return m.Symbol.Global(m.Symbol.None, m.Signature.Term("_empty_"))
+
+      def isLocal(sym: g.Symbol): Boolean = {
+        def definitelyGlobal = sym.hasPackageFlag
+        def definitelyLocal =
+          sym.name.decoded.startsWith(g.nme.LOCALDUMMY_PREFIX) ||
+            sym.name.decodedName == g.tpnme.REFINE_CLASS_NAME ||
+            (sym.owner.isMethod && !sym.isParameter) ||
+            ((sym.owner.isAliasType || sym.owner.isAbstractType) && !sym.isParameter)
+        !definitelyGlobal && (definitelyLocal || isLocal(sym.owner))
+      }
+      // + deviation from scalameta
+      if (isLocal(sym)) {
+        val input = "file://" + sym.pos.source.toString()
+        val point = sym.pos.point
+        return m.Symbol.Local(s"$input@$point..$point")
+      }
+      // - deviation from scalameta
+
+      val owner =
+        sym.owner.toSemantic
+      val signature = {
+        def name(sym: g.Symbol) = sym.name.decoded.stripSuffix(g.nme.LOCAL_SUFFIX_STRING)
+        def jvmSignature(sym: g.MethodSymbol): String = {
+          // NOTE: unfortunately, this simple-looking facility generates side effects that corrupt the state of the compiler
+          // in particular, mixin composition stops working correctly, at least for `object Main extends App`
+          // val g = c.universe.asInstanceOf[scala.tools.nsc.Global]
+          // exitingDelambdafy(new genASM.JPlainBuilder(null, false).descriptor(sym))
+          def encode(tpe: g.Type): String = {
+            val g.TypeRef(_, sym, args) = tpe
+            require(args.isEmpty || sym == g.definitions.ArrayClass)
+            if (sym == g.definitions.UnitClass) "V"
+            else if (sym == g.definitions.BooleanClass) "Z"
+            else if (sym == g.definitions.CharClass) "C"
+            else if (sym == g.definitions.ByteClass) "B"
+            else if (sym == g.definitions.ShortClass) "S"
+            else if (sym == g.definitions.IntClass) "I"
+            else if (sym == g.definitions.FloatClass) "F"
+            else if (sym == g.definitions.LongClass) "J"
+            else if (sym == g.definitions.DoubleClass) "D"
+            else if (sym == g.definitions.ArrayClass) "[" + encode(args.head)
+            else "L" + sym.fullName.replace(".", "/") + ";"
+          }
+          val g.MethodType(params, ret) = sym.info.erasure
+          val jvmRet = if (!sym.isConstructor) ret else g.definitions.UnitClass.toType
+          "(" + params.map(param => encode(param.info)).mkString("") + ")" + encode(jvmRet)
+        }
+
+        if (sym.isMethod && !sym.asMethod.isGetter)
+          m.Signature.Method(name(sym), jvmSignature(sym.asMethod))
+        else if (sym.isTypeParameter) m.Signature.TypeParameter(name(sym))
+        else if (sym.isValueParameter || sym.isParamAccessor) m.Signature.TermParameter(name(sym))
+        else if (sym.owner.thisSym == sym) m.Signature.Self(name(sym))
+        else if (sym.isType) m.Signature.Type(name(sym))
+        else m.Signature.Term(name(sym))
+      }
+      m.Symbol.Global(owner, signature)
+    }
+  }
+}

--- a/sbthost/tests/src/test/scala/scala/meta/tests/SbthostTest.scala
+++ b/sbthost/tests/src/test/scala/scala/meta/tests/SbthostTest.scala
@@ -1,10 +1,9 @@
 package scala.meta
 package tests
 
-import scala.meta.internal.semantic.{vfs => v}
 import scala.meta.internal.semantic.{schema => s}
+import scala.meta.internal.semantic.{vfs => v}
 import scala.meta.sbthost.Sbthost
-import org.scalameta.logger
 
 class SbthostTest extends org.scalatest.FunSuite {
   val entries = v.Database
@@ -20,6 +19,29 @@ class SbthostTest extends org.scalatest.FunSuite {
       val mirror = Sbthost.patchMirror(mattrs)
       org.scalameta.logger.elem(mirror)
       assert(mirror.names.nonEmpty)
+      val syntax = mirror.database.toString()
+      assert(
+        syntax.trim ==
+          """|sbthost/input/src/main/scala/sbthost/CompiledWithSbthost.scala
+             |--------------------------------------------------------------
+             |Dialect:
+             |Scala210
+             |
+             |Names:
+             |[8..15): sbthost => _root_.sbthost.
+             |[23..28): scala => _root_.scala.
+             |[29..39): collection => _root_.scala.collection.
+             |[40..49): immutable => _root_.scala.collection.immutable.
+             |[62..81): CompiledWithSbthost => _root_.sbthost.CompiledWithSbthost.
+             |[90..93): bar => _root_.sbthost.CompiledWithSbthost.bar(I)I.
+             |[94..95): x => _root_.sbthost.CompiledWithSbthost.bar(I)I.(x)
+             |[104..105): x => _root_.sbthost.CompiledWithSbthost.bar(I)I.(x)
+             |[112..115): bar => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.
+             |[116..117): x => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.(x)
+             |[129..130): x => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.(x)
+             |[133..136): bar => _root_.sbthost.CompiledWithSbthost.bar(I)I.
+             |[142..145): bar => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.
+             |""".stripMargin.trim)
       mirror.sources.foreach { source =>
         source.collect {
           case name: Term.Name => mirror.names(name.pos) // error if not found


### PR DESCRIPTION
This commit copy-pasted most of the code from Scalahost with minor
deviations. Most importantly, we use plain vanilla case classes for
Symbol and Input.