### PR TITLE
Handle NoPosition.source for local symbols.

### DIFF
--- a/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SymbolOps.scala
+++ b/sbthost/nsc/src/main/scala/scala/meta/internal/sbthost/SymbolOps.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.sbthost
 
 import java.nio.file.Path
 import scala.meta.internal.{sbthost => m}
+import scala.reflect.internal.util.NoPosition
 
 sealed trait Input
 object Input {
@@ -44,9 +45,12 @@ trait SymbolOps { self: DatabaseOps =>
       }
       // + deviation from scalameta
       if (isLocal(sym)) {
-        val input = "file://" + sym.pos.source.toString()
-        val point = sym.pos.point
-        return m.Symbol.Local(s"$input@$point..$point")
+        if (sym.pos == NoPosition) return Symbol.None
+        else {
+          val input = "file://" + sym.pos.source.toString()
+          val point = sym.pos.point
+          return m.Symbol.Local(s"$input@$point..$point")
+        }
       }
       // - deviation from scalameta
 


### PR DESCRIPTION
I hit on this case while loading a large sbt build with the plugin
enabled. The same bug was fixed recently in scalameta
https://github.com/scalameta/scalameta/issues/959