### PR TITLE
Macros and types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ lazy val input = project
   .settings(
     nonPublishableSettings,
     isScala210,
+    sbtPlugin := true,
     compile.in(Compile) :=
       compile.in(Compile).dependsOn(Keys.`package`.in(nsc, Compile)).value,
     scalacOptions ++= sbtHostScalacOptions.value
@@ -83,13 +84,12 @@ lazy val tests = project
     moduleName := "sbthost-tests",
     scalaVersion := scala212,
     description := "Tests for sbthost",
+    compileInputs.in(Compile, compile) :=
+      compileInputs.in(Compile, compile).dependsOn(compile.in(input, Compile)).value,
     test.in(Test) :=
       test
         .in(Test)
-        .dependsOn(
-          compile.in(input, Compile),
-          scripted.in(sbtTests).toTask("")
-        )
+        .dependsOn(scripted.in(sbtTests).toTask(""))
         .dependsOn(Keys.`package`.in(nsc, Compile))
         .value,
     buildInfoPackage := "scala.meta.tests",

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ lazy val mergeSettings = Def.settings(
 lazy val scalametaVersion = "2.0.0-M2"
 lazy val scala210 = "2.10.6"
 lazy val scala211 = "2.11.11"
-lazy val scala212 = "2.12.2"
+lazy val scala212 = "2.12.3"
 
 lazy val isScala210 = Seq(
   scalaVersion := scala210,

--- a/sbthost/input/src/main/scala/sbthost/CompiledWithSbthost.scala
+++ b/sbthost/input/src/main/scala/sbthost/CompiledWithSbthost.scala
@@ -1,9 +1,14 @@
 package sbthost
 import scala.collection.immutable.Seq
 
+import sbt._
+import sbt.Keys._
+
 object CompiledWithSbthost {
   def bar(x: Int) = x
   def bar(x: String) = x
   bar(1)
   bar("string")
+
+  val x = taskKey[Seq[File]]("")
 }

--- a/sbthost/sbt-tests/src/sbt-test/migration/basic/build.sbt
+++ b/sbthost/sbt-tests/src/sbt-test/migration/basic/build.sbt
@@ -4,5 +4,9 @@ name := "basic" + foo
 // bar
 organization := /* buz */ "me.vican.jorge" + foo
 
+test := Def.task {
+  ()
+}.value
+
 // Definitions
 val p1 = project.in( /* foo */ file(foo))

--- a/sbthost/tests/src/test/scala/scala/meta/tests/SbthostTest.scala
+++ b/sbthost/tests/src/test/scala/scala/meta/tests/SbthostTest.scala
@@ -47,15 +47,24 @@ class ScalaFileTest extends SbthostTest(BuildInfo.sourceroot, BuildInfo.targetro
       |[23..28): scala => _root_.scala.
       |[29..39): collection => _root_.scala.collection.
       |[40..49): immutable => _root_.scala.collection.immutable.
-      |[62..81): CompiledWithSbthost => _root_.sbthost.CompiledWithSbthost.
-      |[90..93): bar => _root_.sbthost.CompiledWithSbthost.bar(I)I.
-      |[94..95): x => _root_.sbthost.CompiledWithSbthost.bar(I)I.(x)
-      |[104..105): x => _root_.sbthost.CompiledWithSbthost.bar(I)I.(x)
-      |[112..115): bar => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.
-      |[116..117): x => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.(x)
-      |[129..130): x => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.(x)
-      |[133..136): bar => _root_.sbthost.CompiledWithSbthost.bar(I)I.
-      |[142..145): bar => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.
+      |[62..65): sbt => _root_.sbt.
+      |[75..78): sbt => _root_.sbt.
+      |[79..83): Keys => _root_.sbt.Keys.
+      |[94..113): CompiledWithSbthost => _root_.sbthost.CompiledWithSbthost.
+      |[122..125): bar => _root_.sbthost.CompiledWithSbthost.bar(I)I.
+      |[126..127): x => _root_.sbthost.CompiledWithSbthost.bar(I)I.(x)
+      |[129..132): Int => _root_.scala.Int#
+      |[136..137): x => _root_.sbthost.CompiledWithSbthost.bar(I)I.(x)
+      |[144..147): bar => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.
+      |[148..149): x => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.(x)
+      |[151..157): String => _root_.scala.Predef.String#
+      |[161..162): x => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.(x)
+      |[165..168): bar => _root_.sbthost.CompiledWithSbthost.bar(I)I.
+      |[174..177): bar => _root_.sbthost.CompiledWithSbthost.bar(Ljava/lang/String;)Ljava/lang/String;.
+      |[195..196): x => _root_.sbthost.CompiledWithSbthost.x.
+      |[199..206): taskKey => _root_.sbt.package.taskKey(Ljava/lang/String;)Lsbt/TaskKey;.
+      |[207..210): Seq => _root_.scala.collection.immutable.Seq#
+      |[211..215): File => _root_.sbt.package.File#
     """.stripMargin
   )
 }
@@ -69,11 +78,18 @@ class SbtFileTest extends SbthostTest(BuildInfo.sbtSourceroot, BuildInfo.sbtTarg
       |Names:
       |[4..7): foo => _root_.<>.foo.
       |[31..35): name => _root_.sbt.Keys.name.
+      |[36..38): := => _root_.sbt.SettingKey#`:=`(Ljava/lang/Object;)Lsbt/Init/Setting;.
       |[47..48): + => _root_.java.lang.String#`+`(Ljava/lang/Object;)Ljava/lang/String;.
       |[49..52): foo => _root_.<>.foo.
       |[60..72): organization => _root_.sbt.Keys.organization.
+      |[73..75): := => _root_.sbt.SettingKey#`:=`(Ljava/lang/Object;)Lsbt/Init/Setting;.
       |[103..104): + => _root_.java.lang.String#`+`(Ljava/lang/Object;)Ljava/lang/String;.
       |[105..108): foo => _root_.<>.foo.
+      |[110..114): test => _root_.sbt.Keys.test.
+      |[115..117): := => _root_.sbt.Scoped.DefinableTask#`:=`(Ljava/lang/Object;)Lsbt/Init/Setting;.
+      |[118..121): Def => _root_.sbt.Def.
+      |[122..126): task => _root_.sbt.Def.task(Ljava/lang/Object;)Lsbt/Init/Initialize;.
+      |[136..141): value => _root_.sbt.std.MacroValue#value()Ljava/lang/Object;.
       |""".stripMargin
   )
 }


### PR DESCRIPTION
Previously, it was not possible to resolve names from macro call-site.
This was problematic for a lot of sbt build code since sbt uses a lot of
macros (`.value`, `taskKey`, `:=`). sbthost also didn't recurse on
TypeTree causing Type.Name to not resolve either.

Review @Duhemm